### PR TITLE
Fix/93 remove prusa specific attributes in the printer maintenance dropdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fdm-monster/client",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": false,
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",

--- a/src/components/Generic/Dialogs/PrinterMaintenanceDialog.vue
+++ b/src/components/Generic/Dialogs/PrinterMaintenanceDialog.vue
@@ -104,7 +104,7 @@ export default defineComponent({
       "X Axis",
       "Y Axis",
       "Rented",
-      "Rambo",
+      "Motherboard",
       "Other",
       "Clean",
     ],


### PR DESCRIPTION
In this case the `Rambo` is one of the items for maintenance. I replaced it with `Motherboard`