### PR TITLE
Feature/77 introduce different grid mechanic (not stuck to 1,2,3,4,6, and 12 divisors)

### DIFF
--- a/src/backend/floor.service.ts
+++ b/src/backend/floor.service.ts
@@ -5,7 +5,6 @@ import {
   Floor,
   getDefaultCreatePrinterFloor,
   PreCreateFloor,
-  PrinterInFloor,
 } from "@/models/printer-floor/printer-floor.model";
 
 export class FloorService extends BaseService {

--- a/src/components/PrinterGrid/PrinterGrid.vue
+++ b/src/components/PrinterGrid/PrinterGrid.vue
@@ -90,8 +90,7 @@ export default defineComponent({
     },
     getPrinter(col: number, row: number) {
       if (!this.printerMatrix?.length || !this.printerMatrix[col - 1]) {
-        console.log("escape", this.printerMatrix[row - 1], row - 1);
-        return undefined;
+        return;
       }
       return this.printerMatrix[col - 1][row - 1];
     },

--- a/src/components/PrinterGrid/PrinterGrid.vue
+++ b/src/components/PrinterGrid/PrinterGrid.vue
@@ -16,40 +16,9 @@
       </div>
       <div class="mt-4">Clear printers by clicking on their tile below:</div>
     </div>
-    <v-row v-for="y in rows" :key="y" class="ma-1" no-gutters>
-      <v-col v-for="x in columns" :key="x" :cols="columnWidth" :sm="columnWidth">
-        <v-row class="test-top" no-gutters>
-          <v-col cols="6">
-            <PrinterGridTile
-              :printer="getPrinter(2 * (x - 1), 2 * (y - 1))"
-              :x="2 * (x - 1)"
-              :y="2 * (y - 1)"
-            />
-          </v-col>
-          <v-col cols="6">
-            <PrinterGridTile
-              :printer="getPrinter(2 * (x - 1) + 1, 2 * (y - 1))"
-              :x="2 * (x - 1) + 1"
-              :y="2 * (y - 1)"
-            />
-          </v-col>
-        </v-row>
-        <v-row class="test-bottom" no-gutters>
-          <v-col cols="6">
-            <PrinterGridTile
-              :printer="getPrinter(2 * (x - 1), 2 * (y - 1) + 1)"
-              :x="2 * (x - 1)"
-              :y="2 * (y - 1) + 1"
-            />
-          </v-col>
-          <v-col cols="6">
-            <PrinterGridTile
-              :printer="getPrinter(2 * (x - 1) + 1, 2 * (y - 1) + 1)"
-              :x="2 * (x - 1) + 1"
-              :y="2 * (y - 1) + 1"
-            />
-          </v-col>
-        </v-row>
+    <v-row v-for="y of rows" :key="y" class="ma-1" no-gutters>
+      <v-col v-for="x of columns" :key="x" :cols="columnWidth" :sm="columnWidth" no-gutters>
+        <PrinterGridTile :printer="getPrinter(x, y)" :x="x" :y="y" />
       </v-col>
     </v-row>
   </div>
@@ -59,11 +28,7 @@
 import { defineComponent } from "vue";
 import { socketIoFloors } from "../../event-bus/socketio.events";
 import PrinterGridTile from "@/components/PrinterGrid/PrinterGridTile.vue";
-import {
-  largeGridColumnCount,
-  largeGridRowCount,
-  totalVuetifyColumnCount,
-} from "@/constants/printer-grid.constants";
+import { gridCols, gridRows, totalVuetifyColumnCount } from "@/constants/printer-grid.constants";
 import { usePrintersStore } from "@/store/printers.store";
 import { Printer } from "../../models/printers/printer.model";
 import { useGridStore } from "../../store/grid.store";
@@ -94,13 +59,13 @@ export default defineComponent({
   },
   computed: {
     columnWidth() {
-      return totalVuetifyColumnCount / this.columns;
+      return totalVuetifyColumnCount / 12;
     },
     columns() {
-      return largeGridColumnCount;
+      return [...Array(gridCols).keys()];
     },
     rows() {
-      return largeGridRowCount;
+      return [...Array(gridRows).keys()];
     },
     printers() {
       return this.printersStore.printers;
@@ -124,10 +89,11 @@ export default defineComponent({
       );
     },
     getPrinter(col: number, row: number) {
-      const x = col;
-      const y = row;
-      if (!this.printerMatrix?.length || !this.printerMatrix[x]) return undefined;
-      return this.printerMatrix[x][y];
+      if (!this.printerMatrix?.length || !this.printerMatrix[col - 1]) {
+        console.log("escape", this.printerMatrix[row - 1], row - 1);
+        return undefined;
+      }
+      return this.printerMatrix[col - 1][row - 1];
     },
     updateGridMatrix() {
       this.printerMatrix = this.printersStore.gridSortedPrinters;
@@ -147,12 +113,10 @@ export default defineComponent({
 
 <style>
 .test-bottom {
-  border: 1px solid transparent;
-  margin: 0 20px 10px 20px !important;
+  //border: 1px solid transparent; //margin: 0 20px 10px 20px !important;
 }
 
 .test-top {
-  border: 1px solid transparent;
-  margin: 0 20px 0 20px !important;
+  //border: 1px solid transparent; //margin: 0 20px 0 20px !important;
 }
 </style>

--- a/src/components/PrinterGrid/PrinterGridTile.vue
+++ b/src/components/PrinterGrid/PrinterGridTile.vue
@@ -98,7 +98,7 @@
         <v-icon size="48">add</v-icon>
         Place printer
       </v-container>
-      <!--      <v-container v-else>  </v-container>-->
+      <v-container v-else> asdasd </v-container>
 
       <v-progress-linear
         v-if="printer && printer.currentJob"

--- a/src/constants/printer-grid.constants.ts
+++ b/src/constants/printer-grid.constants.ts
@@ -1,5 +1,5 @@
 // Should not be adjusted unless the grid system is changed to support other than 12
 export const totalVuetifyColumnCount = 12;
 // Large grid mode
-export const largeGridColumnCount = 4;
-export const largeGridRowCount = 4;
+export const gridCols = 8;
+export const gridRows = 8;

--- a/src/store/printers.store.ts
+++ b/src/store/printers.store.ts
@@ -7,7 +7,7 @@ import { PrinterFileService, PrintersService } from "@/backend";
 import { CreatePrinter } from "@/models/printers/crud/create-printer.model";
 import { FloorService } from "../backend/floor.service";
 import { PrinterJobService } from "@/backend/printer-job.service";
-import { largeGridColumnCount, largeGridRowCount } from "../constants/printer-grid.constants";
+import { gridCols, gridRows } from "../constants/printer-grid.constants";
 
 interface State {
   printers: Printer[];
@@ -54,8 +54,8 @@ export const usePrintersStore = defineStore("Printers", {
       if (!this.selectedFloor) return [];
 
       const positions = this.selectedFloor.printers;
-      const gridY = largeGridRowCount * 2; // X
-      const gridX = largeGridColumnCount * 2; // Y
+      const gridY = gridRows;
+      const gridX = gridCols;
 
       const matrix: (Printer | undefined)[][] = [];
       for (let i = 0; i < gridY; i++) {


### PR DESCRIPTION
In order to reduce the grid column and row count, a bit of rework will need to be done. Luckily none of it is breaking w.r.t. the backend data model!

In this PR I aim to introduce my own grid sizes which will play better with mobile responsiveness.