### PR TITLE
fix: clearing a printer from a floor should not select it

### DIFF
--- a/src/components/PrinterGrid/PrinterGridTile.vue
+++ b/src/components/PrinterGrid/PrinterGridTile.vue
@@ -224,9 +224,11 @@ export default defineComponent({
         const floorId = this.floorStore.selectedFloor?._id;
         if (!floorId) throw new Error("Cant clear printer, floor not selected");
         await FloorService.deletePrinterFromFloor(
-          this.floorStore.selectedFloor!._id,
+          floorId,
           this.printer.id
         );
+
+        return;
       }
 
       this.printersStore.toggleSelectedPrinter(this.printer);

--- a/src/components/PrinterGrid/PrinterGridTile.vue
+++ b/src/components/PrinterGrid/PrinterGridTile.vue
@@ -223,10 +223,7 @@ export default defineComponent({
       if (this.gridStore.gridEditMode) {
         const floorId = this.floorStore.selectedFloor?._id;
         if (!floorId) throw new Error("Cant clear printer, floor not selected");
-        await FloorService.deletePrinterFromFloor(
-          floorId,
-          this.printer.id
-        );
+        await FloorService.deletePrinterFromFloor(floorId, this.printer.id);
 
         return;
       }


### PR DESCRIPTION
Found this when studying the code.