### PR TITLE
hotfix: connecting usb is not possible when offline

### DIFF
--- a/src/components/Generic/FileExplorerSideNav.vue
+++ b/src/components/Generic/FileExplorerSideNav.vue
@@ -117,7 +117,7 @@
       <v-subheader inset>Commands</v-subheader>
 
       <v-list-item
-        :disabled="isStoppable"
+        :disabled="!storedSideNavPrinter?.enabled || !isOnline"
         class="extra-dense-list-item"
         link
         @click.prevent.stop="togglePrinterConnection()"

--- a/src/store/printer-state.store.ts
+++ b/src/store/printer-state.store.ts
@@ -64,7 +64,6 @@ export const usePrinterStateStore = defineStore("PrinterState", {
         const printerEvents = this.printerEventsById[printerId];
         if (!printerEvents) return false;
         const flags = printerEvents?.current?.payload.state.flags;
-        console.log(flags);
         return flags?.printing || flags?.paused;
       };
     },

--- a/src/store/printer-state.store.ts
+++ b/src/store/printer-state.store.ts
@@ -64,6 +64,7 @@ export const usePrinterStateStore = defineStore("PrinterState", {
         const printerEvents = this.printerEventsById[printerId];
         if (!printerEvents) return false;
         const flags = printerEvents?.current?.payload.state.flags;
+        console.log(flags);
         return flags?.printing || flags?.paused;
       };
     },


### PR DESCRIPTION
When opening the sidenav, the connect usb button should be disabled for offline octoprints.