### PR TITLE
fix: remap unfriendly state texts

### DIFF
--- a/src/components/Generic/Dialogs/PrinterChecksPanel.vue
+++ b/src/components/Generic/Dialogs/PrinterChecksPanel.vue
@@ -1,13 +1,8 @@
 <template>
   <v-col :cols="cols">
     <strong>Checks:</strong>
-    <v-alert
-      v-for="(item, index) of testPrinterStore.getEvents()"
-      :key="index"
-      dense
-      :type="item.failure ? 'error' : 'success'"
-    >
-      <small>{{ item.event }} {{ item.payload }}</small>
+    <v-alert v-for="(item, index) of getEvents()" :key="index" dense :type="item.color">
+      <small>{{ item.label }} {{ item.text }}</small>
     </v-alert>
   </v-col>
 </template>
@@ -20,6 +15,9 @@ interface Data {
   cols: 4;
 }
 
+const errorCol = "error";
+const successCol = "success";
+
 export default defineComponent({
   name: "PrinterChecksPanel",
   components: {},
@@ -31,14 +29,24 @@ export default defineComponent({
   data: (): Data => ({
     cols: 4,
   }),
-  computed: {
-    getEvents() {
-      return this.testPrinterStore.getEvents();
-    },
-  },
+  computed: {},
   methods: {
-    isSet(value: boolean) {
-      return value === false || value === true;
+    getEvents() {
+      return this.testPrinterStore.getEvents().map((e) => {
+        let color = e.failure ? errorCol : successCol;
+        const label = e.event;
+        let text = e.payload;
+        if (text === "authFail") {
+          color = errorCol;
+          text = "authentication failed";
+        }
+
+        return {
+          label,
+          text,
+          color,
+        };
+      });
     },
   },
 });

--- a/src/store/test-printer.store.ts
+++ b/src/store/test-printer.store.ts
@@ -35,8 +35,8 @@ export const useTestPrinterStore = defineStore("TestPrinter", {
           )
           .map((e) => ({
             event: e.event === "WS_STATE_UPDATED" ? "Socket" : "API",
-            payload: e.payload,
-            failure: ["authFail", "aborted"].includes(e.payload),
+            payload: e.payload?.replace("noResponse", "Unreachable"),
+            failure: ["authFail", "noResponse", "aborted"].includes(e.payload),
           }));
     },
   },


### PR DESCRIPTION
Small visual fix: failed API state should be colored red and mapped to a bit friendlier text:
![image](https://github.com/fdm-monster/fdm-monster-client/assets/6005355/c96562ee-7ba9-47a1-b01b-a2459046e022)
