### PR TITLE
Feat/represent sentry diag better

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -68,7 +68,7 @@ export default defineComponent({
   },
   async created() {
     await this.settingsStore.loadSettings();
-    const enabled = this.settingsStore.serverSettings?.anonymousDiagnosticsEnabled;
+    const enabled = this.settingsStore.serverSettings?.sentryDiagnosticsEnabled;
     setSentryEnabled(!!enabled);
 
     await this.featureStore.loadFeatures();

--- a/src/backend/server.api.ts
+++ b/src/backend/server.api.ts
@@ -19,7 +19,7 @@ export class ServerApi {
   static serverSettingsRoute = `${ServerApi.settingsRoute}/server`;
   static frontendSettingsRoute = `${ServerApi.serverSettingsRoute}/frontend`;
   static serverWhitelistSettingRoute = `${ServerApi.serverSettingsRoute}/whitelist`;
-  static serverAnonymousDiagnosticSettingRoute = `${ServerApi.serverSettingsRoute}/anonymous-diagnostics`;
+  static serverSentryDiagnosticsSettingRoute = `${ServerApi.serverSettingsRoute}/sentry-diagnostics`;
   static serverRestartRoute = `${ServerApi.serverSettingsRoute}/restart`;
   static customGCodeSettingsRoutes = `${ServerApi.settingsRoute}/custom-gcode`;
   static pluginRoute = `${ServerApi.base}/plugin`;

--- a/src/backend/settings.service.ts
+++ b/src/backend/settings.service.ts
@@ -21,8 +21,8 @@ export class SettingsService extends BaseService {
     return (await this.putApi(path, frontendSettings as FrontendSettings)) as SettingsDto;
   }
 
-  static async setAnonymousDiagnosticsSettings(enabled: boolean) {
-    const path = `${ServerApi.serverAnonymousDiagnosticSettingRoute}`;
+  static async setSentryDiagnosticsSettings(enabled: boolean) {
+    const path = `${ServerApi.serverSentryDiagnosticsSettingRoute}`;
     return await this.patchApi(path, { enabled });
   }
 

--- a/src/components/Settings/SoftwareUpgradeSettings.vue
+++ b/src/components/Settings/SoftwareUpgradeSettings.vue
@@ -76,15 +76,15 @@
       </v-list-item>
       <v-list-item v-if="hasAnonymousDiagnosticsToggleFeature">
         <v-list-item-content>
-          <v-list-item-title>Anonymous diagnostic reports:</v-list-item-title>
+          <v-list-item-title>Remote Sentry diagnostic reports:</v-list-item-title>
           <v-list-item-subtitle>
             <v-checkbox
-              v-model="anonymousDiagnosticsEnabled"
-              label="Enable anonymous diagnostic reports (Sentry)"
+              v-model="sentryDiagnosticsEnabled"
+              label="Enable remote Sentry diagnostic reports"
             />
 
             <br />
-            <v-btn color="primary" @click="saveAnonymousDiagnosticsSettings()">
+            <v-btn color="primary" @click="saveSentryDiagnosticsSettings()">
               <v-icon class="pr-2">save</v-icon>
               Save
             </v-btn>
@@ -113,7 +113,7 @@ const current = ref<IRelease>();
 const minimum = ref<IRelease>();
 const selectedRelease = ref<string>();
 const hasAnonymousDiagnosticsToggleFeature = ref(false);
-const anonymousDiagnosticsEnabled = ref(false);
+const sentryDiagnosticsEnabled = ref(false);
 
 onMounted(async () => {
   const clientReleases = await AppService.getClientReleases();
@@ -130,8 +130,7 @@ onMounted(async () => {
     features.anonymousDiagnosticsToggle?.available || false;
 
   await settingsStore.loadSettings();
-  anonymousDiagnosticsEnabled.value =
-    settingsStore.serverSettings?.anonymousDiagnosticsEnabled || false;
+  sentryDiagnosticsEnabled.value = settingsStore.serverSettings?.sentryDiagnosticsEnabled || false;
 });
 
 function isCurrentRelease(release: IRelease) {
@@ -155,8 +154,8 @@ async function clickUpdateClient(tagName: string) {
   location.reload();
 }
 
-async function saveAnonymousDiagnosticsSettings() {
-  await SettingsService.setAnonymousDiagnosticsSettings(anonymousDiagnosticsEnabled.value);
-  setSentryEnabled(anonymousDiagnosticsEnabled.value);
+async function saveSentryDiagnosticsSettings() {
+  await SettingsService.setSentryDiagnosticsSettings(sentryDiagnosticsEnabled.value);
+  setSentryEnabled(sentryDiagnosticsEnabled.value);
 }
 </script>

--- a/src/models/settings/serverSettings.ts
+++ b/src/models/settings/serverSettings.ts
@@ -7,5 +7,5 @@ export interface ServerSettings extends WhitelistSettings {
   registration: boolean;
   port: number;
   loginRequired: boolean;
-  anonymousDiagnosticsEnabled: boolean;
+  sentryDiagnosticsEnabled: boolean;
 }


### PR DESCRIPTION
The diagnostics are not anonymous and are remote. Both those terms are important to some users out there.
The backend has been changed to opt-in instead of opt-out.