### PR TITLE
fix: disable pause resume button when printer has no job or is offline

### DIFF
--- a/src/components/Generic/FileExplorerSideNav.vue
+++ b/src/components/Generic/FileExplorerSideNav.vue
@@ -165,7 +165,7 @@
 
       <v-list-item
         v-if="featureStore.hasFeature('pauseResumePrinterCommand')"
-        :disabled="!isFileBeingPrinted"
+        :disabled="!currentJob || !isOnline"
         class="extra-dense-list-item"
         link
         @click.prevent.stop="isPaused ? clickResumePrint() : clickPausePrint()"


### PR DESCRIPTION
This was a bug as a wrong function was used (and not even called).