### PR TITLE
fix: hide and clear test events after dialog close action

### DIFF
--- a/src/components/Generic/Dialogs/CreatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/CreatePrinterDialog.vue
@@ -159,6 +159,8 @@ export default defineComponent({
       this.closeDialog();
     },
     closeDialog() {
+      this.showChecksPanel = false;
+      this.testPrinterStore.clearEvents();
       this.dialogsStore.closeDialog(this.dialogId);
       this.copyPasteConnectionString = "";
     },

--- a/src/components/Generic/Dialogs/UpdatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/UpdatePrinterDialog.vue
@@ -170,6 +170,8 @@ export default defineComponent({
       this.closeDialog();
     },
     closeDialog() {
+      this.showChecksPanel = false;
+      this.testPrinterStore.clearEvents();
       this.dialogsStore.closeDialog(this.dialogId);
       this.printersStore.setUpdateDialogPrinter(undefined);
       this.copyPasteConnectionString = "";


### PR DESCRIPTION
This makes the dialog slightly more predictable to open and re-open.