### PR TITLE
fix: make printer relocate mode clearer

### DIFF
--- a/src/components/PrinterGrid/PrinterGrid.vue
+++ b/src/components/PrinterGrid/PrinterGrid.vue
@@ -1,21 +1,32 @@
 <template>
   <div>
-    <div v-if="gridStore.gridEditMode" class="ml-4 mt-4 mb-0" style="cursor: move">
-      <span class="pr-4">
-        Drag and drop {{ floorStore.floorlessPrinters.length }} unplaced printer(s) here:
-      </span>
-      <div
-        v-for="printer of floorStore.floorlessPrinters"
-        :key="printer.id"
-        class="d-inline-block text-center mr-1 mb-1"
-        draggable="true"
-        style="width: 100px; height: 40px; border: 1px solid gray; border-radius: 2px"
-        @dragstart="onDragStart(printer, $event)"
-      >
-        <strong text-center>{{ printer.printerName }}</strong>
-      </div>
-      <div class="mt-4">Clear printers by clicking on their tile below:</div>
-    </div>
+    <v-banner v-if="gridStore.gridEditMode" style="cursor: move">
+      <v-row style="margin-bottom: -5px">
+        <v-col>
+          <span>
+            Drag {{ floorStore.floorlessPrinters.length }} unplaced printer(s) from here to place it
+            on the grid.
+          </span>
+          <v-chip-group>
+            <v-chip
+              v-for="printer of floorStore.floorlessPrinters"
+              :key="printer.id"
+              draggable
+              small
+              @dragstart="onDragStart(printer, $event)"
+            >
+              {{ printer.printerName }}
+            </v-chip>
+          </v-chip-group>
+        </v-col>
+        <v-col>
+          <div>
+            Clear printers by clicking on
+            <strong> <v-icon>disabled_visible</v-icon> Click to clear </strong>
+          </div>
+        </v-col>
+      </v-row>
+    </v-banner>
     <v-row v-for="y in rows" :key="y" class="ma-1" no-gutters>
       <v-col v-for="x in columns" :key="x" :cols="columnWidth" :sm="columnWidth">
         <v-row class="test-top" no-gutters>

--- a/src/components/PrinterGrid/PrinterGridTile.vue
+++ b/src/components/PrinterGrid/PrinterGridTile.vue
@@ -120,10 +120,12 @@
             <v-icon>menu_open</v-icon>
           </v-btn>
         </div>
-        <strong v-else class="float-end">
-          <v-icon>disabled_visible</v-icon>
-          Click to clear
-        </strong>
+        <div v-else class="float-end">
+          <strong class="pl-5 pr-5" color="primary">
+            <v-icon>disabled_visible</v-icon>
+            Click to clear
+          </strong>
+        </div>
         <br />
 
         <v-tooltip

--- a/src/components/PrinterGrid/PrinterGridView.vue
+++ b/src/components/PrinterGrid/PrinterGridView.vue
@@ -2,7 +2,7 @@
   <div>
     <HomeToolbar />
 
-    <v-banner v-drop-upload="{ printers: selectedPrinters }">
+    <v-banner v-drop-upload="{ printers: selectedPrinters }" v-if="!gridStore.gridEditMode">
       <v-row style="margin-bottom: -5px">
         <v-col style="padding: 5px 0 0 15px">
           <v-chip-group class="d-inline-block">
@@ -88,12 +88,14 @@ import { usePrinterStore } from "../../store/printer.store";
 import { useUploadsStore } from "@/store/uploads.store";
 import { useFeatureStore } from "../../store/features.store";
 import { usePrinterStateStore } from "../../store/printer-state.store";
+import { useGridStore } from "../../store/grid.store";
 
 export default defineComponent({
   name: "PrinterGridView",
   components: { PrinterGrid, HomeToolbar },
   setup: () => {
     return {
+      gridStore: useGridStore(),
       printersStore: usePrinterStore(),
       printerStateStore: usePrinterStateStore(),
       uploadsStore: useUploadsStore(),


### PR DESCRIPTION
The relocate hides the printer selection bar from normal mode.