### PR TITLE
fix: reset forms after create or update

### DIFF
--- a/src/components/Generic/Dialogs/CreatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/CreatePrinterDialog.vue
@@ -161,6 +161,7 @@ export default defineComponent({
     closeDialog() {
       this.showChecksPanel = false;
       this.testPrinterStore.clearEvents();
+      this.printerCrudForm().resetForm();
       this.dialogsStore.closeDialog(this.dialogId);
       this.copyPasteConnectionString = "";
     },

--- a/src/components/Generic/Dialogs/UpdatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/UpdatePrinterDialog.vue
@@ -172,6 +172,7 @@ export default defineComponent({
     closeDialog() {
       this.showChecksPanel = false;
       this.testPrinterStore.clearEvents();
+      this.printerUpdateForm().resetForm();
       this.dialogsStore.closeDialog(this.dialogId);
       this.printersStore.setUpdateDialogPrinter(undefined);
       this.copyPasteConnectionString = "";


### PR DESCRIPTION
The dialog forms were not reset after closure.