### PR TITLE
fix(client): setting navbar breaking down small sizes

### DIFF
--- a/src/components/Settings/SettingsView.vue
+++ b/src/components/Settings/SettingsView.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row no-gutters>
     <div>
-      <v-navigation-drawer>
+      <v-navigation-drawer permanent="true">
         <v-list-item>
           <v-list-item-content>
             <v-list-item-title class="text-h6"> Settings</v-list-item-title>


### PR DESCRIPTION
Fix Issue #126 When resizing screen to small size the navbar disappears.

Before:

   

https://github.com/fdm-monster/fdm-monster-client/assets/61384954/695f0d3a-9df5-4f55-b53b-7a40fb585702



After:

https://github.com/fdm-monster/fdm-monster-client/assets/61384954/3f177471-4e98-4fc9-8ec7-734f709e885a


References:
https://vuetifyjs.com/en/api/v-navigation-drawer/

