### PR TITLE
chore: remove old commented out printer silent state mapping

### DIFF
--- a/src/shared/printer-state.constants.ts
+++ b/src/shared/printer-state.constants.ts
@@ -108,15 +108,6 @@ export function interpretStates(
     };
   }
 
-  // if (printerState?.expired) {
-  //   return {
-  //     ...state,
-  //     color: COLOR.danger,
-  //     rgb: RGB.Red,
-  //     text: LABEL.Disconnected,
-  //     description: printerState.text || "Please check if the USB cable was disconnected/broken",
-  //   };
-
   if (!flags) {
     console.error("No flags", flags);
     return;


### PR DESCRIPTION
Remove old commented out printer silent state mapping