### PR TITLE
Fix/334 log dump is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fdm-monster/client",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "private": false,
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",

--- a/src/backend/server-private.service.ts
+++ b/src/backend/server-private.service.ts
@@ -32,9 +32,6 @@ export class ServerPrivateService extends BaseService {
 
   public static async downloadLogDump() {
     const response = await this.postApi("api/server/dump-fdm-monster-logs");
-    await downloadFileByBlob(
-      (response as any).data as any,
-      "logs-fdm-monster-" + Date.now() + ".zip"
-    );
+    await downloadFileByBlob(response as any as any, "logs-fdm-monster-" + Date.now() + ".zip");
   }
 }

--- a/src/utils/download-file.util.ts
+++ b/src/utils/download-file.util.ts
@@ -1,6 +1,9 @@
 import { apiBase } from "../backend/base.service";
 
 export function downloadFileByBlob(data: ArrayBuffer, fileName: string) {
+  if (!data) {
+    throw new Error("No data to download");
+  }
   const blob = new Blob([data], { type: "text" });
   const link = document.createElement("a");
   link.href = URL.createObjectURL(blob);


### PR DESCRIPTION
The ZIP was empty as the `data` property was already unwrapped by the base method.