### PR TITLE
fix: disable boundary type for inferred class types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     "@typescript-eslint/explicit-module-boundary-types": isProduction ? "warn" : "off",
     "@typescript-eslint/no-empty-function": isProduction ? "warn" : "off",
     "@typescript-eslint/no-inferrable-types": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/ban-ts-comment": "warn",
     "vue/valid-v-slot": [
       "error",

--- a/src/backend/base.service.ts
+++ b/src/backend/base.service.ts
@@ -4,7 +4,7 @@ import Vue from "vue";
 export const apiBase = Vue.config.devtools ? "http://127.0.0.1:4000" : ""; // Same-origin policy
 
 export class BaseService {
-  static readonly UNWRAP = { unwrap: true };
+  private static readonly UNWRAP = { unwrap: true };
 
   protected static async getApi<R>(path: string, options = this.UNWRAP) {
     const response = await axios.get<R>(`${apiBase}/${path}`);

--- a/src/backend/floor.service.ts
+++ b/src/backend/floor.service.ts
@@ -1,7 +1,7 @@
 import { BaseService } from "@/backend/base.service";
 import { ServerApi } from "@/backend/server.api";
-import { newRandomNamePair } from "../shared/noun-adjectives.data";
-import { Floor, getDefaultCreateFloor, PreCreateFloor } from "../models/floors/floor.model";
+import { newRandomNamePair } from "@/shared/noun-adjectives.data";
+import { Floor, getDefaultCreateFloor, PreCreateFloor } from "@/models/floors/floor.model";
 
 export class FloorService extends BaseService {
   static convertPrinterFloorToCreateForm(printerFloor?: Floor): PreCreateFloor {

--- a/src/shared/socketio.service.ts
+++ b/src/shared/socketio.service.ts
@@ -7,7 +7,7 @@ import { usePrinterStore } from "@/store/printer.store";
 import { apiBase } from "@/backend/base.service";
 import { useFloorStore } from "@/store/floor.store";
 import { usePrinterStateStore } from "@/store/printer-state.store";
-import { useTestPrinterStore } from "../store/test-printer.store";
+import { useTestPrinterStore } from "@/store/test-printer.store";
 import { useSnackbar } from "./snackbar.composable";
 
 enum IO_MESSAGES {
@@ -19,12 +19,12 @@ enum IO_MESSAGES {
 }
 
 export class SocketIoService {
-  socket: Socket;
-  printerStore = usePrinterStore();
-  floorStore = useFloorStore();
-  printerStateStore = usePrinterStateStore();
-  testPrinterStore = useTestPrinterStore();
-  snackbar = useSnackbar();
+  private socket: Socket;
+  private printerStore = usePrinterStore();
+  private floorStore = useFloorStore();
+  private printerStateStore = usePrinterStateStore();
+  private testPrinterStore = useTestPrinterStore();
+  private snackbar = useSnackbar();
 
   setupSocketConnection() {
     this.socket = io(apiBase);


### PR DESCRIPTION
https://typescript-eslint.io/rules/explicit-module-boundary-types/

This rule forces public class methods to have an explicit return type. This PR disables this until further notice.