### PR TITLE
fix: ensure api client path resolution is absolute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fdm-monster/client",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": false,
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",

--- a/src/backend/server.api.ts
+++ b/src/backend/server.api.ts
@@ -1,5 +1,5 @@
 export class ServerApi {
-  static base = "api";
+  static base = "/api";
   static amIAliveRoute = `${ServerApi.base}/amialive`;
   static printerRoute = `${ServerApi.base}/printer`;
   static printerBatchRoute = `${ServerApi.printerRoute}/batch`;

--- a/src/shared/http-client.ts
+++ b/src/shared/http-client.ts
@@ -6,7 +6,8 @@ import Vue from "vue";
  * Made async for future possibility of getting base URI externally or asynchronously
  */
 export async function getBaseUri() {
-  return Vue.config.devtools ? "http://127.0.0.1:4000" : ""; // Same-origin policy
+  // return Vue.config.devtools ? "https://demo.fdm-monster.net" : "";
+  return Vue.config.devtools ? "http://localhost:4000/" : "/"; // Same-origin policy
 }
 
 export function getHttpClient(withAuth: boolean = true) {


### PR DESCRIPTION
fixes API calls going to the wrong relative path

release: 1.3.1