### PR TITLE
Fix/fdmm3082 dialog initialization causes app loading errors

### DIFF
--- a/src/backend/server-private.service.ts
+++ b/src/backend/server-private.service.ts
@@ -2,8 +2,7 @@ import { BaseService } from "@/backend/base.service";
 import { ServerApi } from "@/backend/server.api";
 import { ExportYamlModel } from "@/models/server/export-yaml.model";
 import { downloadFileByBlob } from "@/utils/download-file.util";
-import axios from "axios";
-import { getBaseUri, getHttpClient } from "@/shared/http-client";
+import { getHttpClient } from "@/shared/http-client";
 
 export class ServerPrivateService extends BaseService {
   public static async restartServer() {
@@ -20,10 +19,7 @@ export class ServerPrivateService extends BaseService {
       data: input,
       responseType: "blob",
     });
-    await downloadFileByBlob(
-      (response as any).data as any,
-      "export-fdm-monster-" + Date.now() + ".yaml"
-    );
+    downloadFileByBlob((response as any).data as any, "export-fdm-monster-" + Date.now() + ".yaml");
   }
 
   public static async uploadAndImportYaml(file: File) {
@@ -39,7 +35,7 @@ export class ServerPrivateService extends BaseService {
       url: `api/server/dump-fdm-monster-logs`,
       responseType: "blob",
     });
-    await downloadFileByBlob((response as any).data, "logs-fdm-monster-" + Date.now() + ".zip");
+    downloadFileByBlob((response as any).data, "logs-fdm-monster-" + Date.now() + ".zip");
   }
 
   public static async clearLogFilesOlderThanWeek() {

--- a/src/components/Generic/Dialogs/AddOrUpdateCameraStreamDialog.vue
+++ b/src/components/Generic/Dialogs/AddOrUpdateCameraStreamDialog.vue
@@ -81,7 +81,7 @@ watch(
       .getQueryData<CameraWithPrinter[]>(["cameraStream"])
       ?.find((cameraStream) => cameraStream.cameraStream.id === context.cameraId);
     cameraStream.value.name = stream?.cameraStream.name;
-    cameraStream.value.streamURL = stream?.cameraStream.streamURL;
+    cameraStream.value.streamURL = stream?.cameraStream.streamURL || "";
   }
 );
 

--- a/src/components/Generic/Dialogs/AddOrUpdateFloorDialog.vue
+++ b/src/components/Generic/Dialogs/AddOrUpdateFloorDialog.vue
@@ -106,8 +106,6 @@ export default defineComponent({
       this.formData.floor = maxIndex.toString();
     }
   },
-  async mounted() {},
-  props: {},
   data: (): Data => ({
     formData: getDefaultCreateFloor(),
   }),

--- a/src/components/Generic/Dialogs/BatchJsonCreateDialog.vue
+++ b/src/components/Generic/Dialogs/BatchJsonCreateDialog.vue
@@ -84,8 +84,6 @@ export default defineComponent({
   async created() {
     this.numPrinters = 0;
   },
-  async mounted() {},
-  props: {},
   data: (): Data => ({
     formData: {
       json: "",

--- a/src/components/Generic/Dialogs/BatchReprintDialog.vue
+++ b/src/components/Generic/Dialogs/BatchReprintDialog.vue
@@ -99,14 +99,6 @@ const selectedItems = ref<ReprintFileDto[]>([]);
 const errorLoading = ref("");
 const snackbar = useSnackbar();
 
-onMounted(() => {
-  console.debug("Mounted");
-});
-
-onBeforeUnmount(() => {
-  console.debug("Unmount");
-});
-
 function onBeforeDialogOpened(_: IdType[]) {
   loading.value = true;
 }

--- a/src/components/Generic/Dialogs/YamlImportExportDialog.vue
+++ b/src/components/Generic/Dialogs/YamlImportExportDialog.vue
@@ -1,5 +1,10 @@
 <template>
-  <BaseDialog :id="dialog.dialogId" max-width="700px" @escape="closeDialog()">
+  <BaseDialog
+    :id="dialog.dialogId"
+    @beforeOpened="onBeforeDialogOpened"
+    max-width="700px"
+    @escape="closeDialog()"
+  >
     <v-card class="pa-4">
       <v-card-title>
         <span class="text-h5"> YAML export and import </span>
@@ -92,10 +97,6 @@ export default defineComponent({
       snackbar: useSnackbar(),
     };
   },
-  async created() {
-    await this.featureStore.loadFeatures();
-    this.exportGroups = this.featureStore.hasFeature("printerGroupsApi");
-  },
   data: (): Data => ({
     selectedMode: 0,
     exportFloors: true,
@@ -117,6 +118,10 @@ export default defineComponent({
     },
   },
   methods: {
+    async onBeforeDialogOpened() {
+      await this.featureStore.loadFeatures();
+      this.exportGroups = this.featureStore.hasFeature("printerGroupsApi");
+    },
     async downloadExportYamlFile() {
       if (this.exportFloorGrid) {
         this.exportPrinters = true;

--- a/src/components/PrinterList/PrintersView.vue
+++ b/src/components/PrinterList/PrintersView.vue
@@ -228,6 +228,7 @@ import { useQuery } from "@tanstack/vue-query";
 import { useSnackbar } from "@/shared/snackbar.composable";
 import { GroupWithPrintersDto, PrinterGroupService } from "@/backend/printer-group.service";
 import { AppService } from "@/backend/app.service";
+import { useDialog } from "@/shared/dialog.composable";
 
 const snackbar = useSnackbar();
 const printerStore = usePrinterStore();
@@ -331,7 +332,7 @@ const openImportJsonPrintersDialog = () => {
 };
 
 const openYamlImportExportDialog = () => {
-  dialogsStore.openDialogWithContext(DialogName.YamlImportExport);
+  useDialog(DialogName.YamlImportExport).openDialog();
 };
 
 const createGroup = async () => {

--- a/src/shared/dialog.composable.ts
+++ b/src/shared/dialog.composable.ts
@@ -8,14 +8,14 @@ export function useDialog<T = any, O = any>(dialogId: DialogName) {
   async function openDialog(context?: T) {
     const beforeOpenedCallback = dialogStore.getBeforeOpenedCallback(dialogId);
     if (beforeOpenedCallback) {
-      beforeOpenedCallback(context);
+      await beforeOpenedCallback(context);
     }
 
     dialogStore.openDialogWithContext(dialogId, context);
 
     const openedCallback = dialogStore.getOpenedCallback(dialogId);
     if (openedCallback) {
-      openedCallback(context);
+      await openedCallback(context);
     }
   }
 

--- a/src/store/dialog.store.ts
+++ b/src/store/dialog.store.ts
@@ -4,8 +4,8 @@ import { DialogName } from "@/components/Generic/Dialogs/dialog.constants";
 interface DialogReference<T = any> {
   id: DialogName;
   opened: boolean;
-  beforeOpenedCallback?: (input?: T) => void;
-  openedCallback?: (input?: T) => void;
+  beforeOpenedCallback?: (input?: T) => void | Promise<void>;
+  openedCallback?: (input?: T) => void | Promise<void>;
   context?: any;
   output?: any;
 }

--- a/src/store/features.store.ts
+++ b/src/store/features.store.ts
@@ -20,8 +20,6 @@ export const useFeatureStore = defineStore("Feature", {
         if (!state.features) {
           console.debug("Feature store not loaded");
           return false;
-        } else {
-          console.debug("Feature store loaded");
         }
 
         const featureDefined = state.features[feature] as IFeatureFlag | undefined;


### PR DESCRIPTION
This analyzes and fixes initialization errors with the dialogs of FDM Monster Client.
When not logged in, or when not permitted, the features API will respond with 403 code. This will redirect any component to the permission denied page, which makes completing the first time setup (or anything for that matter) very hard.

The features API was called by the yaml dialog: a dialog that has not been opened, but simply is being initialized. This initialization has nothing to do with the actual page flow. Assuming the error was not avoidable, instead the permission/network error should be handled inside the dialog (preferably after the dialog has been opened). This could be an override in the http client which prevents error handling (event emits). An new improvement issue should be made to track the progress of that followup task.

Another challenge I found: the composable dialog has callback hooks, but the store has not. Maybe verify other dialog usage to ensure the hooks work when needed (if no hooks are needed direct store usage is fine).