### PR TITLE
Feat/fdmm 2024 handle GitHub rate limit UI

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,4 +1,16 @@
-# Client 13/04/2024 1.5.8
+# Client 13/04/2024 develop
+
+Features:
+
+- Settings: Software Upgrade - the GitHub API limit will be tested and shown in the software upgrade UI before attempting to load releases
+- Settings Use a feature flag to determine if server can provide GitHub rate limit information
+
+Changes:
+
+- Settings: The settings toolbars have been refactored: consistent icon, simpler titles and dark color
+- Settings: The settings navigation has been re-ordered and given separations
+
+# Client 13/04/2024 1.5.9
 
 Features:
 

--- a/src/backend/app.service.ts
+++ b/src/backend/app.service.ts
@@ -3,6 +3,7 @@ import { VersionModel } from "@/models/server/version.model";
 import { FeaturesModel } from "@/models/server/features.model";
 import { IClientReleases } from "@/models/server/client-releases.model";
 import { getHttpClient } from "@/shared/http-client";
+import { GithubRateLimit } from "@/models/server/github-rate-limit.model";
 
 export class AppService extends BaseService {
   static async updateClientDistGithub(version?: string, allowDowngrade?: boolean) {
@@ -10,6 +11,10 @@ export class AppService extends BaseService {
       downloadRelease: version,
       allowDowngrade,
     });
+  }
+
+  static async getGithubRateLimit() {
+    return (await this.getApi("api/server/github-rate-limit")) as GithubRateLimit;
   }
 
   static async getClientReleases() {

--- a/src/components/Settings/AccountSettings.vue
+++ b/src/components/Settings/AccountSettings.vue
@@ -1,11 +1,7 @@
 <template>
   <v-card>
-    <v-toolbar color="primary">
-      <v-avatar>
-        <v-icon>account_circle</v-icon>
-      </v-avatar>
-      <v-toolbar-title>Account Settings</v-toolbar-title>
-    </v-toolbar>
+    <SettingsToolbar icon="account_circle" title="Account" />
+
     <v-list subheader three-line>
       <v-list-item-content>
         <v-list-item>
@@ -99,6 +95,7 @@ import { useAuthStore } from "@/store/auth.store";
 import { routeToLogin } from "@/router/utils";
 import { useRouter } from "vue-router/composables";
 import { useSettingsStore } from "@/store/settings.store";
+import SettingsToolbar from "@/components/Settings/Shared/SettingsToolbar.vue";
 
 const settingsStore = useSettingsStore();
 const profileStore = useProfileStore();

--- a/src/components/Settings/DiagnosticsSettings.vue
+++ b/src/components/Settings/DiagnosticsSettings.vue
@@ -1,11 +1,7 @@
 <template>
   <v-card>
-    <v-toolbar color="primary">
-      <v-avatar>
-        <v-icon>bug_report</v-icon>
-      </v-avatar>
-      <v-toolbar-title>Diagnostics</v-toolbar-title>
-    </v-toolbar>
+    <SettingsToolbar icon="bug_report" title="Diagnostics" />
+
     <v-list subheader three-line>
       <v-subheader
         >Diagnostics to provide bug reports to the developers of this software
@@ -73,6 +69,7 @@ import { setSentryEnabled } from "@/utils/sentry.util";
 import { ServerPrivateService } from "@/backend/server-private.service";
 import { useSnackbar } from "@/shared/snackbar.composable";
 import { captureException } from "@sentry/vue";
+import SettingsToolbar from "@/components/Settings/Shared/SettingsToolbar.vue";
 
 const snackBar = useSnackbar();
 const settingsStore = useSettingsStore();

--- a/src/components/Settings/EmergencyCommands.vue
+++ b/src/components/Settings/EmergencyCommands.vue
@@ -1,11 +1,7 @@
 <template>
   <v-card>
-    <v-toolbar color="primary">
-      <v-avatar>
-        <v-icon>settings</v-icon>
-      </v-avatar>
-      <v-toolbar-title>Emergency Commands</v-toolbar-title>
-    </v-toolbar>
+    <SettingsToolbar icon="warning" title="Emergency Commands" />
+
     <v-list subheader three-line>
       <v-subheader>Emergency Commands to rectify problematic situations</v-subheader>
 
@@ -111,6 +107,7 @@ import { Bar } from "vue-chartjs";
 import { IdType } from "@/utils/id.type";
 import { OctoPrintSettingsDto } from "@/backend/dto/octoprint-settings.dto";
 import { sleep } from "@/utils/time.utils";
+import SettingsToolbar from "@/components/Settings/Shared/SettingsToolbar.vue";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 

--- a/src/components/Settings/FloorSettings.vue
+++ b/src/components/Settings/FloorSettings.vue
@@ -1,11 +1,6 @@
 <template>
   <v-card>
-    <v-toolbar color="primary">
-      <v-avatar>
-        <v-icon>settings</v-icon>
-      </v-avatar>
-      <v-toolbar-title>Floor Management</v-toolbar-title>
-    </v-toolbar>
+    <SettingsToolbar icon="house_siding" title="Floors" />
 
     <v-list subheader three-line>
       <v-subheader>Floors</v-subheader>
@@ -133,6 +128,7 @@ import { DialogName } from "@/components/Generic/Dialogs/dialog.constants";
 import { PrinterDto } from "@/models/printers/printer.model";
 import { useFloorStore } from "@/store/floor.store";
 import { useSnackbar } from "@/shared/snackbar.composable";
+import SettingsToolbar from "@/components/Settings/Shared/SettingsToolbar.vue";
 
 interface Data {
   editedFloorName: string;
@@ -142,6 +138,7 @@ interface Data {
 
 export default defineComponent({
   name: "FloorSettings",
+  components: { SettingsToolbar },
   setup: () => {
     return {
       printersStore: usePrinterStore(),

--- a/src/components/Settings/GridSettings.vue
+++ b/src/components/Settings/GridSettings.vue
@@ -1,11 +1,6 @@
 <template>
   <v-card>
-    <v-toolbar color="primary">
-      <v-avatar>
-        <v-icon>settings</v-icon>
-      </v-avatar>
-      <v-toolbar-title>Grid Settings</v-toolbar-title>
-    </v-toolbar>
+    <SettingsToolbar icon="grid_on" title="Grid" />
 
     <v-list subheader three-line>
       <v-subheader>Grid Rows and Columns</v-subheader>
@@ -61,6 +56,7 @@ import { defineComponent } from "vue";
 import { useSettingsStore } from "../../store/settings.store";
 import { colOptions, rowOptions } from "../../shared/printer-grid.constants";
 import { useSnackbar } from "@/shared/snackbar.composable";
+import SettingsToolbar from "@/components/Settings/Shared/SettingsToolbar.vue";
 
 interface Data {
   property: number;
@@ -68,7 +64,7 @@ interface Data {
 
 export default defineComponent({
   name: "GridSettings",
-  components: {},
+  components: { SettingsToolbar },
   setup: () => {
     return {
       settingsStore: useSettingsStore(),

--- a/src/components/Settings/OctoPrintSettings.vue
+++ b/src/components/Settings/OctoPrintSettings.vue
@@ -1,11 +1,7 @@
 <template>
   <v-card>
-    <v-toolbar color="primary">
-      <v-avatar>
-        <v-icon>settings</v-icon>
-      </v-avatar>
-      <v-toolbar-title>OctoPrint Settings</v-toolbar-title>
-    </v-toolbar>
+    <SettingsToolbar icon="bug_report" title="OctoPrint" />
+
     <v-list subheader three-line>
       <v-list-item>
         <v-list-item-content>
@@ -90,6 +86,7 @@ import { usePrinterStore } from "@/store/printer.store";
 import { usePrinterStateStore } from "@/store/printer-state.store";
 import { useSnackbar } from "@/shared/snackbar.composable";
 import { useSettingsStore } from "@/store/settings.store";
+import SettingsToolbar from "@/components/Settings/Shared/SettingsToolbar.vue";
 
 interface Data {
   fileHandlingSettings: FileCleanSettings;
@@ -97,6 +94,7 @@ interface Data {
 
 export default defineComponent({
   name: "FdmSettings",
+  components: { SettingsToolbar },
   setup: () => {
     return {
       settingsStore: useSettingsStore(),

--- a/src/components/Settings/ServerProtectionSettings.vue
+++ b/src/components/Settings/ServerProtectionSettings.vue
@@ -1,11 +1,7 @@
 <template>
   <v-card>
-    <v-toolbar color="primary">
-      <v-avatar>
-        <v-icon>settings</v-icon>
-      </v-avatar>
-      <v-toolbar-title>Server Protection Settings</v-toolbar-title>
-    </v-toolbar>
+    <SettingsToolbar icon="security" title="Server Protection" />
+
     <v-list subheader three-line>
       <v-list-item v-if="!whitelistSettingsHidden">
         <v-list-item-content>
@@ -187,6 +183,7 @@ import { useSnackbar } from "@/shared/snackbar.composable";
 import { useAuthStore } from "@/store/auth.store";
 import { useRouter } from "vue-router/composables";
 import { RouteNames } from "@/router/route-names";
+import SettingsToolbar from "@/components/Settings/Shared/SettingsToolbar.vue";
 
 const router = useRouter();
 const snackbar = useSnackbar();

--- a/src/components/Settings/SettingsView.vue
+++ b/src/components/Settings/SettingsView.vue
@@ -12,7 +12,14 @@
         <v-divider></v-divider>
 
         <v-list dense nav>
-          <v-list-item v-for="item in items" :key="item.title" :to="item.path" link router-link>
+          <v-list-item
+            v-for="item in items"
+            :key="item.title"
+            :to="item.path"
+            link
+            router-link
+            :style="item.divider ? 'border-bottom: 1px solid gray' : ''"
+          >
             <v-list-item-icon>
               <v-icon>{{ item.icon }}</v-icon>
             </v-list-item-icon>
@@ -29,60 +36,54 @@
   </v-row>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
-import { usePrinterStore } from "@/store/printer.store";
+<script lang="ts" setup>
+import { ref } from "vue";
 
-interface Data {
-  items: any[];
-}
-
-export default defineComponent({
-  name: "SettingsView",
-  components: {},
-  setup: () => {
-    return {
-      printersStore: usePrinterStore(),
-    };
+const items = ref([
+  {
+    title: "Grid",
+    icon: "grid_on",
+    path: "/settings/grid",
+    divider: false,
   },
-  async created() {},
-  async mounted() {},
-  props: {},
-  data: (): Data => ({
-    items: [
-      {
-        title: "Grid",
-        icon: "grid_on",
-        path: "/settings/grid",
-      },
-      {
-        title: "Floors",
-        icon: "house_siding",
-        path: "/settings/floors",
-      },
-      {
-        title: "User Management",
-        icon: "group",
-        path: "/settings/user-management",
-      },
-      {
-        title: "Account Settings",
-        icon: "account_circle",
-        path: "/settings/account",
-      },
-      {
-        title: "Server Protection",
-        icon: "security",
-        path: "/settings/server-protection",
-      },
-      { title: "OctoPrint Settings", icon: "image", path: "/settings/octoprint" },
-      { title: "Emergency Commands", icon: "warning", path: "/settings/emergency-commands" },
-      { title: "Software Upgrade", icon: "upgrade", path: "/settings/software-upgrade" },
-      { title: "Diagnostics", icon: "bug_report", path: "/settings/diagnostics" },
-    ],
-  }),
-  computed: {},
-  methods: {},
-  watch: {},
-});
+  {
+    title: "Floors",
+    icon: "house_siding",
+    path: "/settings/floors",
+    divider: true,
+  },
+  { title: "OctoPrint", icon: "image", path: "/settings/octoprint", divider: false },
+
+  {
+    title: "Emergency Commands",
+    icon: "warning",
+    path: "/settings/emergency-commands",
+    divider: true,
+  },
+  {
+    title: "Users",
+    icon: "group",
+    path: "/settings/user-management",
+    divider: false,
+  },
+  {
+    title: "Account",
+    icon: "account_circle",
+    path: "/settings/account",
+    divider: true,
+  },
+  {
+    title: "Server Protection",
+    icon: "security",
+    path: "/settings/server-protection",
+    divider: false,
+  },
+  {
+    title: "Software Upgrade",
+    icon: "upgrade",
+    path: "/settings/software-upgrade",
+    divider: false,
+  },
+  { title: "Diagnostics", icon: "bug_report", path: "/settings/diagnostics", divider: false },
+]);
 </script>

--- a/src/components/Settings/Shared/SettingsToolbar.vue
+++ b/src/components/Settings/Shared/SettingsToolbar.vue
@@ -1,0 +1,11 @@
+<template>
+  <v-toolbar>
+    <v-avatar>
+      <v-icon>{{ props.icon }}</v-icon>
+    </v-avatar>
+    <v-toolbar-title>{{ props.title }}</v-toolbar-title>
+  </v-toolbar>
+</template>
+<script setup lang="ts">
+const props = defineProps(["icon", "title"]);
+</script>

--- a/src/components/Settings/UserManagementSettings.vue
+++ b/src/components/Settings/UserManagementSettings.vue
@@ -1,17 +1,14 @@
 <template>
   <v-card>
-    <v-toolbar color="primary">
-      <v-avatar>
-        <v-icon>settings</v-icon>
-      </v-avatar>
-      <v-toolbar-title>Users</v-toolbar-title>
-    </v-toolbar>
+    <SettingsToolbar icon="group" title="Users" />
+
     <GridLoader
       v-if="loading"
       :size="20"
       color="#a70015"
       style="margin: 250px; position: absolute"
     />
+
     <v-list subheader three-line>
       <v-subheader>Showing all users</v-subheader>
 
@@ -99,6 +96,7 @@ import { formatIntlDate } from "@/utils/date.utils";
 import GridLoader from "@/components/Generic/Loaders/GridLoader.vue";
 import { useQuery } from "@tanstack/vue-query";
 import { useSnackbar } from "@/shared/snackbar.composable";
+import SettingsToolbar from "@/components/Settings/Shared/SettingsToolbar.vue";
 
 const snackbar = useSnackbar();
 const loading = ref<boolean>(false);

--- a/src/models/server/features.model.ts
+++ b/src/models/server/features.model.ts
@@ -16,6 +16,7 @@ export class FeaturesModel {
   cameraStream?: IFeatureFlag;
   printerGroupsApi?: IFeatureFlag;
   printerControlApi?: IFeatureFlag;
+  githubRateLimitApi?: IFeatureFlag;
 }
 
 export type TFeatureFlags = keyof FeaturesModel;
@@ -32,4 +33,5 @@ export const featureFlagsList: TFeatureFlags[] = [
   "cameraStream",
   "printerGroupsApi",
   "printerControlApi",
+  "githubRateLimitApi",
 ];

--- a/src/models/server/github-rate-limit.model.ts
+++ b/src/models/server/github-rate-limit.model.ts
@@ -1,0 +1,21 @@
+export interface GithubRateLimit {
+  // For us: core resource
+  rate: Rate;
+  // Resources like core, graphql, integration_manifest and search
+  resources: Resources;
+}
+
+export interface Resources {
+  core: Rate;
+  graphql: Rate;
+  integration_manifest: Rate;
+  search: Rate;
+}
+
+export interface Rate {
+  limit: number;
+  remaining: number;
+  reset: number;
+  used: number;
+  resource: string;
+}


### PR DESCRIPTION
Client version of https://github.com/fdm-monster/fdm-monster/pull/3116

![image](https://github.com/fdm-monster/fdm-monster/assets/6005355/8ab88a53-6b0e-467f-b1e9-d10967b4c681)

- [x] The GitHub API limit will be tested and shown in the software upgrade UI before attempting to load releases
- [x] The settings toolbars have been refactored: consistent icon, simpler titles and dark color
- [x] The settings navigation has been re-ordered and given separations
- [x] Use a feature flag to determine if server can provide github rate limit information