### PR TITLE
Fix/prevent nullref issues printerstate util

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -7,6 +7,7 @@ Fixes:
 - Printer dialog: adapt form label based on requirement of api key (octoprint: yes, moonraker: no)
 - Batch reprint dialog mentions OctoPrint, should be type dependent
 - Settings page: experimental settings - improve visual confirmation by introducing save spinners and checkboxes
+- Sometimes empty flags can be passed (regressions backend...) prevent errors
 
 ## Client 27/10/2024 1.6.5
 

--- a/src/shared/printer-state.constants.ts
+++ b/src/shared/printer-state.constants.ts
@@ -142,7 +142,7 @@ export function interpretStates(
 const toCurrentState = (printerState: PrinterStateDto) => printerState?.current?.payload?.state;
 
 export const isPrinterPrinting = (printerState: PrinterStateDto) =>
-  toCurrentState(printerState)?.flags.printing;
+  toCurrentState(printerState)?.flags?.printing;
 
 export const isPrinterPaused = (printerState: PrinterStateDto) =>
   toCurrentState(printerState)?.flags?.paused || toCurrentState(printerState)?.flags?.pausing;
@@ -150,9 +150,9 @@ export const isPrinterPaused = (printerState: PrinterStateDto) =>
 export const isPrinterDisconnected = (printer: PrinterDto, printerState: PrinterStateDto) =>
   (!isPrinterInMaintenance(printer) &&
     printer?.enabled &&
-    !toCurrentState(printerState)?.flags.operational) ||
-  toCurrentState(printerState)?.flags.error ||
-  toCurrentState(printerState)?.flags.closedOrError;
+    !toCurrentState(printerState)?.flags?.operational) ||
+  toCurrentState(printerState)?.flags?.error ||
+  toCurrentState(printerState)?.flags?.closedOrError;
 
 export const isPrinterDisabled = (printer: PrinterDto) =>
   !isPrinterInMaintenance(printer) && !printer?.enabled;
@@ -162,7 +162,7 @@ export const isPrinterInMaintenance = (printer?: PrinterDto) =>
 
 export const isPrinterIdling = (printer: PrinterDto, printerState: PrinterStateDto) =>
   toCurrentState(printerState)?.flags &&
-  !toCurrentState(printerState)?.flags.printing &&
-  toCurrentState(printerState)?.flags.operational &&
+  !toCurrentState(printerState)?.flags?.printing &&
+  toCurrentState(printerState)?.flags?.operational &&
   !isPrinterDisabled(printer) &&
   !isPrinterInMaintenance(printer);


### PR DESCRIPTION
This bug is another one on the list of regressions introduced by the backend moonraker type #1216 

The bug was caused by the "current" refresh loop lacking progress/job and (at one point) writing state text instead of the flags+text+error object.