### PR TITLE
Fix/adjust printer api key 43 length max

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,11 @@
 # Release notes
 
+## Client 11/11/2024 1.6.8
+
+Fixes: 
+
+- Printer dialog: api key of 43 length should be allowed since OctoPrint 1.10.3
+
 ## Client 04/11/2024 1.6.7
 Fixes:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fdm-monster/client",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "author": "David Zwart",
   "license": "AGPL-3.0-or-later",
   "repository": {

--- a/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
@@ -75,7 +75,7 @@
               v-model="formData.apiKey"
               :counter="apiKeyRules.length"
               class="ma-1"
-              hint="User or Application Key only (Global API key will fail)"
+              hint="User or Application Key with 32 or 43 characters (Global API key will fail)"
               :label="formData.printerType === 1 ? 'API Key (optional)' : 'API Key (required)*'"
               persistent-hint
               required

--- a/src/shared/app.constants.ts
+++ b/src/shared/app.constants.ts
@@ -13,7 +13,7 @@ export interface AppConstants {
 
 export const generateAppConstants = (): Readonly<AppConstants> =>
   Object.freeze({
-    apiKeyLength: 32,
+    apiKeyLength: 43,
     maxPort: 65535,
     maxPrinterNameLength: 25,
     maxPrinterGroupNameLength: 30, // Doesn't exist on backend


### PR DESCRIPTION
This fixes frontend api key validation to allow 43 characters in the input field. This is not a showstopper on the frontend though, just a visual helping hand.

Associated with https://github.com/fdm-monster/fdm-monster/issues/3752