### PR TITLE
fix: when deleting a printer, an error is often presented that the PrinterStore contains no printer with such id

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,11 @@
 # Release notes
 
+Fixes
+
+- PrinterStore: when deleting a printer, an error is often presented that the PrinterStore contains no printer with such id
+ 
+Features
+
 - User settings: create user dialog for an admin to conveniently share a new verified account with roles. 
 
 ## Client 11/11/2024 1.6.10

--- a/src/components/Generic/Actions/PrinterDeleteAction.vue
+++ b/src/components/Generic/Actions/PrinterDeleteAction.vue
@@ -8,15 +8,21 @@
 import { defineProps } from "vue";
 import { PrinterDto } from "@/models/printers/printer.model";
 import { usePrinterStore } from "@/store/printer.store";
+import { usePrinterStateStore } from "@/store/printer-state.store";
 
 const props = defineProps<{
   printer: PrinterDto;
 }>();
 
 const printersStore = usePrinterStore();
+const printerStateStore = usePrinterStateStore();
 
 async function deletePrinter() {
   if (!confirm("Are you sure to delete this printer?")) return;
+
   await printersStore.deletePrinter(props.printer.id);
+
+  // This is a best-effort, the socket-io updates will decide eventually
+  printerStateStore.deletePrinterEvents(props.printer.id);
 }
 </script>

--- a/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
+++ b/src/components/Generic/Dialogs/AddOrUpdatePrinterDialog.vue
@@ -141,6 +141,7 @@ import { isMoonrakerType } from "@/utils/printer-type.utils";
 const dialog = useDialog(DialogName.AddOrUpdatePrinterDialog);
 const printersStore = usePrinterStore();
 const testPrinterStore = useTestPrinterStore();
+const featureStore = useFeatureStore();
 const appConstants = inject<AppConstants>("appConstants");
 const snackbar = useSnackbar();
 
@@ -181,7 +182,6 @@ const serviceTypes = computed(() => {
 });
 
 const printerId = computed(() => printersStore.updateDialogPrinter?.id);
-const featureStore = useFeatureStore();
 
 onMounted(async () => {
   if (printerId.value) {

--- a/src/store/printer-state.store.ts
+++ b/src/store/printer-state.store.ts
@@ -170,7 +170,7 @@ export const usePrinterStateStore = defineStore("PrinterState", {
             });
           } else {
             console.debug(
-              `PrinterStore[printersWithJob contains no printer with id ${id} but events are known`
+              `PrinterStore[printersWithJob] contains no printer with id ${id} but events are known`
             );
           }
         }

--- a/src/store/printer-state.store.ts
+++ b/src/store/printer-state.store.ts
@@ -31,7 +31,9 @@ export const usePrinterStateStore = defineStore("PrinterState", {
           if (printer) {
             printersById[id] = printer;
           } else {
-            throw new Error(`PrinterStore contains no printer with id ${id} but events are known`);
+            console.debug(
+              `PrinterStore[operationalPrintersById] contains no printer with id ${id} but events are known`
+            );
           }
         }
       });
@@ -91,8 +93,8 @@ export const usePrinterStateStore = defineStore("PrinterState", {
           if (printer) {
             onlinePrinters[id] = printer;
           } else {
-            throw new Error(
-              `PrinterStore contains no printer with id ${id} but socket state is opened`
+            console.debug(
+              `PrinterStore[onlinePrinters] contains no printer with id ${id} but socket state is opened`
             );
           }
         }
@@ -140,7 +142,9 @@ export const usePrinterStateStore = defineStore("PrinterState", {
           if (printer) {
             printersWithJobById[printer.id] = printerEvents?.current?.payload;
           } else {
-            throw new Error(`PrinterStore contains no printer with id ${id} but events are known`);
+            console.debug(
+              `PrinterStore[printerJobsById] contains no printer with id ${id} but events are known`
+            );
           }
         }
       });
@@ -165,7 +169,9 @@ export const usePrinterStateStore = defineStore("PrinterState", {
               job: printerEvents?.current?.payload,
             });
           } else {
-            throw new Error(`PrinterStore contains no printer with id ${id} but events are known`);
+            console.debug(
+              `PrinterStore[printersWithJob contains no printer with id ${id} but events are known`
+            );
           }
         }
       });


### PR DESCRIPTION
This is an inconsistency coming from the backend which has no "deleted" or "updated" mechanism. Also there is no state normalization, so the frontend cannot correctly see which entities should be updated and which should be silenced/deleted.

Fixes
https://github.com/fdm-monster/fdm-monster/issues/3778