### PR TITLE
fix: deleting or downloading a file path is now encoded in url path

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,8 +1,12 @@
 # Release notes
 
+Fixes
+
+- File delete/download: Deleting or downloading a file path is now encoded in url path
+
 Features
 
-- feat: add ability to swap out quick stop for cancel on printer tiles
+- Printer tile: Add ability to swap out quick stop for cancel on printer tiles
 
 ## Client 23/11/2024 1.7.2
 

--- a/src/backend/printer-file.service.ts
+++ b/src/backend/printer-file.service.ts
@@ -60,12 +60,14 @@ export class PrinterFileService extends BaseService {
   }
 
   static async deleteFileOrFolder(printerId: IdType, path: string) {
-    const urlPath = `${ServerApi.printerFilesRoute}/${printerId}?path=${path}`;
+    const urlPath = `${ServerApi.printerFilesRoute}/${printerId}?path=${encodeURIComponent(path)}`;
     return this.delete(urlPath);
   }
 
   static async downloadFile(printerId: IdType, path: string) {
-    const urlPath = `${ServerApi.printerFilesRoute}/${printerId}/download/${path}`;
+    const urlPath = `${ServerApi.printerFilesRoute}/${printerId}/download/${encodeURIComponent(
+      path
+    )}`;
     const arrayBuffer = await this.getDownload(urlPath);
     downloadFileByBlob(arrayBuffer.data, path);
   }


### PR DESCRIPTION
Fixes frontend part of https://github.com/fdm-monster/fdm-monster/issues/3800