### PR TITLE
feat:  printer tile: re-implement compact tile, the opposite of large tile mode

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # Release notes
 
+Features
+
+- Printer tile: re-implement compact tile, the opposite of large tile mode
+
 ## Client 13/12/2024 1.8.4
 
 Features

--- a/src/components/PrinterGrid/PrinterGrid.vue
+++ b/src/components/PrinterGrid/PrinterGrid.vue
@@ -41,7 +41,7 @@
             />
           </div>
         </div>
-        <!-- Columns -->
+        <!-- Columns increment/decrement -->
         <div
           v-if="gridStore.gridEditMode"
           class="d-flex flex-row justify-start"
@@ -66,7 +66,7 @@
           </v-btn>
         </div>
       </div>
-      <!-- Rows -->
+      <!-- Rows increment/decrement -->
       <div
         v-if="gridStore.gridEditMode"
         class="d-flex flex-column justify-start"

--- a/src/components/PrinterGrid/PrinterGrid.vue
+++ b/src/components/PrinterGrid/PrinterGrid.vue
@@ -30,6 +30,9 @@
             v-for="index in totalCells"
             :key="`printer-${getX(index - 1)}-${getY(index - 1)}`"
             class="printer-cell"
+            :class="{
+              'printer-cell-large': largeTileMode,
+            }"
           >
             <PrinterGridTile
               :printer="getPrinter(getX(index - 1), getY(index - 1))"
@@ -123,6 +126,7 @@ const props = defineProps({
 const printerMatrix = computed(() => floorStore.gridSortedPrinters);
 const columns = computed(() => settingsStore.gridCols);
 const rows = computed(() => settingsStore.gridRows);
+const largeTileMode = computed(() => settingsStore.largeTiles);
 
 const totalCells = computed(() => rows.value * columns.value);
 const gridStyle = computed(() => ({
@@ -192,6 +196,10 @@ async function decrementGridCols() {
 }
 
 .printer-cell {
+  padding: 4px;
+}
+
+.printer-cell-large {
   padding: 8px;
 }
 

--- a/src/components/PrinterGrid/PrinterGridTile.vue
+++ b/src/components/PrinterGrid/PrinterGridTile.vue
@@ -245,13 +245,6 @@
         <template v-slot:default="{ value }">
           <strong>
             {{ value?.toFixed(1) + "%" }}
-            <!--            {{-->
-            <!--              largeTilesEnabled-->
-            <!--                ? value-->
-            <!--                  ? value?.toFixed(1) + "%"-->
-            <!--                  : "&nbsp;"-->
-            <!--                : currentPrintingFilePath-->
-            <!--            }}-->
           </strong>
 
           <v-tooltip


### PR DESCRIPTION
Required feature for power users.

Small tile mode
![image](https://github.com/user-attachments/assets/ab3daabf-ed19-4d12-8215-d09e2aea7f70)

Large tile mode
![image](https://github.com/user-attachments/assets/931260bd-303f-4610-9f4c-97448489929b)
