### PR TITLE
fix: clicking on an empty tile should not enable grid mode

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # Release notes
 
+Fixes
+
+- Printer tile: clicking on an empty tile should not enable grid mode 
+
 ## Client 23/12/2024 1.8.6
 
 Features

--- a/src/components/PrinterGrid/PrinterGridTile.vue
+++ b/src/components/PrinterGrid/PrinterGridTile.vue
@@ -454,7 +454,6 @@ const clickConnectUsb = async () => {
 
 const selectOrClearPrinterPosition = async () => {
   if (!props.printer || !printerId.value) {
-    gridStore.gridEditMode = true;
     return;
   }
 
@@ -464,6 +463,7 @@ const selectOrClearPrinterPosition = async () => {
     await FloorService.deletePrinterFromFloor(floorId, printerId.value);
     return;
   }
+
   printerStore.toggleSelectedPrinter(props.printer);
 };
 </script>
@@ -506,6 +506,7 @@ const selectOrClearPrinterPosition = async () => {
 
 .tile-no-printer:hover {
   background-color: #2a2a2a;
+  cursor: not-allowed;
 }
 
 .plus-hover-icon {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d5d95a11-0746-4210-a739-dc3bcccd2a86)
Clicking the empty tile would enable grid edit mode. Unexpected behaviour.