### PR TITLE
fix: delete all files should have a confirmation dialog

### DIFF
--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -1,5 +1,9 @@
 # Release notes
 
+Fixes
+
+- Delete files on printer details (sidenav) should be protected by a confirmation dialog. 
+
 ## Client 25/12/2024 1.8.7
 
 Fixes

--- a/src/components/Generic/FileExplorerSideNav.vue
+++ b/src/components/Generic/FileExplorerSideNav.vue
@@ -277,7 +277,7 @@
             link
             v-bind="attrs"
             v-on="on"
-            @click.prevent.stop="clickClearFiles()"
+            @click.prevent.stop="clickDeleteAllFiles()"
           >
             <v-list-item-avatar>
               <v-icon>delete</v-icon>
@@ -681,10 +681,14 @@ async function clickResumePrint() {
   await PrinterJobService.resumePrintJob(printerId.value);
 }
 
-async function clickClearFiles() {
+async function clickDeleteAllFiles() {
   if (!printerId.value) return;
+  if (!confirm("Are you sure to delete all files for this printer?")) {
+    return;
+  }
+
   loading.value = true;
-  await printersStore.clearPrinterFiles(printerId.value);
+  await printersStore.deletePrinterFiles(printerId.value);
   loading.value = false;
   shownFileCache.value = printersStore.printerFiles(printerId.value);
 }

--- a/src/store/printer.store.ts
+++ b/src/store/printer.store.ts
@@ -145,7 +145,7 @@ export const usePrinterStore = defineStore("Printers", {
         console.warn("Printer was not purged as it did not occur in state", printerId);
       }
     },
-    async clearPrinterFiles(printerId: IdType) {
+    async deletePrinterFiles(printerId: IdType) {
       if (!printerId) {
         throw new Error("No printerId was provided");
       }


### PR DESCRIPTION
Fixes https://github.com/fdm-monster/fdm-monster/issues/3947

![image](https://github.com/user-attachments/assets/e15571bd-01bf-4ae3-a8e6-f638bfd3c9b0)
The delete files option is currently unprotected against misclicks.